### PR TITLE
Bug fix:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
     image: elastest/ebs-spark:latest
     depends_on:
       - spark-master
+    # Normally we should be able to use this environment variable in order to substitute all 
+    # configuration files with the correct spark-master.
+    # Leaving this here for reference, for the time being.
+    environment:
+      - SPARK_MASTER_HOSTNAME=spark-master
     ports:
       - "8081"
     # volumes:

--- a/spark/slave.conf
+++ b/spark/slave.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:spark-slave]
-command=/opt/spark/sbin/start-slave.sh spark://spark:7077
+command=/opt/spark/sbin/start-slave.sh spark://spark-master:7077


### PR DESCRIPTION
Currently the built spark image has a wrong configuration for the spark-master.
I changed the /opt/conf/slave.conf file to point to the correct spark-master hostname.

docker-compose.yml contains a harmless change, as a reminder to provide a more flexible
solution to this spark-master naming issue.